### PR TITLE
isolate Signaling related code

### DIFF
--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -52,8 +52,6 @@ extern "C" {
 #define INET6 1
 #include <usrsctp.h>
 
-#include <libwebsockets.h>
-
 #if !defined __WINDOWS_BUILD__
 #include <signal.h>
 #include <sys/types.h>
@@ -65,6 +63,7 @@ extern "C" {
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #endif
 
 // Max uFrag and uPwd length as documented in https://tools.ietf.org/html/rfc5245#section-15.4
@@ -149,11 +148,6 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "Rtp/Codecs/RtpH264Payloader.h"
 #include "Rtp/Codecs/RtpOpusPayloader.h"
 #include "Rtp/Codecs/RtpG711Payloader.h"
-#include "Signaling/FileCache.h"
-#include "Signaling/Signaling.h"
-#include "Signaling/ChannelInfo.h"
-#include "Signaling/StateMachine.h"
-#include "Signaling/LwsApiCalls.h"
 #include "Metrics/Metrics.h"
 
 ////////////////////////////////////////////////////

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -1,5 +1,5 @@
 #define LOG_CLASS "ChannelInfo"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* ppChannelInfo)
 {

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -1,5 +1,5 @@
 #define LOG_CLASS "SignalingClient"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 STATUS createRetryStrategyForCreatingSignalingClient(PSignalingClientInfo pClientInfo, PKvsRetryStrategy pKvsRetryStrategy)
 {

--- a/src/source/Signaling/FileCache.c
+++ b/src/source/Signaling/FileCache.c
@@ -1,5 +1,5 @@
 #define LOG_CLASS "SignalingFileCache"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 /****************************************************************************************************
  * Content of the caching file will look as follows:

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2,7 +2,7 @@
  * Implementation of a API calls based on LibWebSocket
  */
 #define LOG_CLASS "LwsApiCalls"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 static BOOL gInterruptedFlagBySignalHandler;
 VOID lwsSignalHandler(INT32 signal)

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -1,5 +1,5 @@
 #define LOG_CLASS "Signaling"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 extern StateMachineState SIGNALING_STATE_MACHINE_STATES[];
 extern UINT32 SIGNALING_STATE_MACHINE_STATE_COUNT;

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -2,7 +2,7 @@
  * Implementation of a signaling states machine callbacks
  */
 #define LOG_CLASS "SignalingState"
-#include "../Include_i.h"
+#include "../SignalingInclude.h"
 
 /**
  * Static definitions of the states

--- a/src/source/SignalingInclude.h
+++ b/src/source/SignalingInclude.h
@@ -1,0 +1,25 @@
+/*******************************************
+Internal include file about signaling
+*******************************************/
+#ifndef __KINESIS_VIDEO_WEBRTC_CLIENT_SIGNALING_INCLUDE__
+#define __KINESIS_VIDEO_WEBRTC_CLIENT_SIGNALING_INCLUDE__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libwebsockets.h>
+
+#include "Include_i.h"
+#include "Signaling/FileCache.h"
+#include "Signaling/Signaling.h"
+#include "Signaling/ChannelInfo.h"
+#include "Signaling/StateMachine.h"
+#include "Signaling/LwsApiCalls.h"
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_WEBRTC_CLIENT_SIGNALING_INCLUDE__ */

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "../src/source/Include_i.h"
+#include "../src/source/SignalingInclude.h"
 #include <memory>
 #include <string>
 #include <thread>


### PR DESCRIPTION
If you don't need signaling functionality, you don't need to download or
compile its dependency like libwebsockets, kvsCommonLws.

Issue #, if available:
None

Description of changes:
This commit separate Signaling related code from the other part of the SDK. It give us a chance to remove libwebsockets/kvsCommonLws dependency, so that we can use some other signaling mechanism.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.